### PR TITLE
fix: photo gallery click conflict and tag contrast in light mode

### DIFF
--- a/pages/photos/[slug].tsx
+++ b/pages/photos/[slug].tsx
@@ -1,5 +1,5 @@
 import { GetStaticPropsContext } from "next"
-import { useState } from "react"
+import { useRef, useState } from "react"
 import { styled } from "styled-components"
 import FadeInImage from "../../components/FadeInImage"
 import FullscreenImageViewer from "../../components/FullscreenImageViewer"
@@ -34,17 +34,24 @@ export default function Post({ photoSet }: Props) {
   const { title, photos, date } = photoSet
   const [fullscreenImage, setFullscreenImage] = useState<string | null>(null)
   const [isFullscreenOpen, setIsFullscreenOpen] = useState(false)
+  // Prevent opening a new photo while the viewer is in the process of closing.
+  // Without this flag, clicking the overlay on top of another photo would close
+  // the current viewer AND immediately open the next one (both end up closed).
+  const isClosingRef = useRef(false)
 
   const handleImageClick = (photo: string) => {
+    if (isClosingRef.current) return
     setFullscreenImage(photo)
     setIsFullscreenOpen(true)
   }
 
   const handleCloseFullscreen = () => {
+    isClosingRef.current = true
     setIsFullscreenOpen(false)
     // Delay clearing the image data to allow fade-out animation
     setTimeout(() => {
       setFullscreenImage(null)
+      isClosingRef.current = false
     }, 450) // Match animation duration
   }
 

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -128,8 +128,8 @@ const TechStack = styled.div`
 const TechBadge = styled.span`
   padding: 0.4rem 0.8rem;
   font-size: 0.85rem;
-  background: ${lightTheme.primary}33;
-  color: ${lightTheme.background};
+  background: ${lightTheme.primary}22;
+  color: ${lightTheme.primary};
 
   @media (prefers-color-scheme: dark) {
     background: ${darkTheme.primary}22;


### PR DESCRIPTION
## Changes

### Bug 1 — Photo gallery click conflict
When a fullscreen photo was open and the user clicked the overlay over another photo in the grid, both the close and open handlers fired simultaneously — the new photo tried to open while the current one was closing, resulting in both ending up closed (glitch).

**Fix:** Added an `isClosingRef` flag in the photo slug page. When `handleCloseFullscreen` is called, the flag is set to `true` immediately, and `handleImageClick` bails out early if the flag is set. The flag is reset after the 450ms fade-out animation completes. This ensures that the click which dismisses the current viewer cannot simultaneously open a new one.

### Bug 2 — App tags (TechBadge) low contrast in light mode
The `TechBadge` component in `projects.tsx` was using:
- `background: ${lightTheme.primary}33` → near-black at ~20% opacity → renders as light grey
- `color: ${lightTheme.background}` → `#EEEEEE` (near-white)

White text on light grey = very low contrast.

**Fix:** Changed to:
- `background: ${lightTheme.primary}22` → slightly more subtle background
- `color: ${lightTheme.primary}` → `#040404` (near-black), excellent contrast on light background

Dark mode styling is unchanged.